### PR TITLE
Allow manual trigger of org management action

### DIFF
--- a/.github/workflows/peribolos.yaml
+++ b/.github/workflows/peribolos.yaml
@@ -1,5 +1,6 @@
 name: Apply Organization Membership
 on:
+  workflow_dispatch: {}
   push:
     branches:
       - 'main'


### PR DESCRIPTION
## Description
<!-- Provide full justification for why this organization membership change is being requested -->
<!-- Identify the relevant sponsors or maintainers for each team where a new user is being added -->

## New Open Data Hub Member Requirements
- [ ] New members have reviewed and acknowledged the Open Data Hub:
  - [Code of Conduct](https://github.com/opendatahub-io/opendatahub-community/blob/main/CODE_OF_CONDUCT.md)
  - [Contribution Guide](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributing.md)
  - [Community Membership Guidelines](https://github.com/opendatahub-io/opendatahub-community/blob/main/community-membership.md)
- [ ] [Enabled 2FA on their GitHub account](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication)

## Pull Request Requirements
- [ ] New members are added in alphabetical order
- [ ] Only one new member change per commit (if you add two members separate it in two commits
- [ ] For individual user changes: Commit message format `Add <USERNAME> to <opendatahub-io, mlops-sig, ...>`. 
- [ ] For new team requests: Commit message format `Create <TEAMNAME>`. If the new team consists solely of existing members, you may 
- [ ] New GitHub team requests are from an existing opendatahub-io member who will function as the maintainer of the team. Each additional member will follow the same requirements for adding new members
